### PR TITLE
replace psycopg2 libs

### DIFF
--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -3,7 +3,7 @@
   apt:
     pkg:
       - libpq-dev
-      - python-psycopg2
+      - python3-psycopg2
   tags:
     - packages
 


### PR DESCRIPTION
this fixes `Failed to import the required Python library (psycopg2)` for python3